### PR TITLE
Initialize empty array

### DIFF
--- a/s3-common-functions
+++ b/s3-common-functions
@@ -34,7 +34,7 @@ readonly base64encode="openssl enc -base64 -e -in"
 readonly base64decode="openssl enc -base64 -d -in"
 
 # Globals
-declare -a temporaryFiles
+temporaryFiles=( )
 
 function base64EncodedMD5
 {


### PR DESCRIPTION
The `declare -a temporaryFiles` didn't work for me on Ubuntu 14.04, which uses GNU Bash 4.3                    (2014 February 2). Using `temporaryFiles=( )` works though. This change is compatible with GNU Bash-3.2                   (2006 September 28), which is what my version of OS X is using.